### PR TITLE
populate SparkConf from HiveConf, fix jdo dep issue

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -12,7 +12,7 @@ object Dependencies {
   val sparkDependencies = Seq(
     "org.apache.spark" %% "spark-core" % sparkHDPVersion,
     "org.apache.spark" %% "spark-sql"  % sparkHDPVersion,
-    "org.apache.spark" %% "spark-hive" % sparkHDPVersion
+    "org.apache.spark" %% "spark-hive" % sparkHDPVersion  exclude("org.spark-project.hive", "hive-metastore") exclude("org.spark-project.hive", "hive-exec")
   )
 
   val testDependencies = Seq(

--- a/test/src/test/scala/com/virtuslab/tools/HiveMetastoreSpec.scala
+++ b/test/src/test/scala/com/virtuslab/tools/HiveMetastoreSpec.scala
@@ -24,6 +24,8 @@ object HiveMetastoreSpec {
     .setHiveConf(new HiveConf())
     .build()
 
+  val hiveConf = instance.getHiveConf
+
   private val started = new AtomicBoolean(false)
 
   def start() = {

--- a/test/src/test/scala/com/virtuslab/tools/SparkSpec.scala
+++ b/test/src/test/scala/com/virtuslab/tools/SparkSpec.scala
@@ -7,11 +7,11 @@ trait SparkSpec extends ClusterSpec  { this: Suite =>
 
   implicit val spark: SparkSession = SparkSession
       .builder()
-      .config("hive.metastore.uris", HiveMetastoreSpec.uri)
-      .config("spark.sql.warehouse.dir", HiveMetastoreSpec.warehouseDirectory)
       .master("local")
       .appName("Spark test")
       .enableHiveSupport()
       .getOrCreate()
+
+  spark.sparkContext.hadoopConfiguration.addResource(HiveMetastoreSpec.hiveConf)
 
 }


### PR DESCRIPTION
As mentioned on https://github.com/sakserv/hadoop-mini-clusters/issues/61 there is a new parquet lib conflict issue, but this resolves the other issues we've discussed.